### PR TITLE
Add curated BASB resource recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-06-13
+
+- Added official Building a Second Brain hubs, including the resource guide and podcast.
+- Added Forte Labs resources on PKM levels, BASB misconceptions, and AI second brain workflows.
+- Added practical BASB notes, video, and template resources for Maggie Appleton, YouTube, Workflowy, and Obsidian.
+
 ## 2026-06-12
 
 - Added canonical Building a Second Brain and PARA book links.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added official Building a Second Brain hubs, including the resource guide and podcast.
 - Added Forte Labs resources on PKM levels, BASB misconceptions, and AI second brain workflows.
 - Added practical BASB notes, video, and template resources for Maggie Appleton, YouTube, Workflowy, and Obsidian.
+- Normalized existing Forte Labs links to the current `fortelabs.com` domain.
 
 ## 2026-06-12
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
   - [Articles](#articles)
   - [Books](#books)
+  - [Official Hubs](#official-hubs)
   - [Courses](#courses)
   - [Videos](#videos)
   - [Templates and Examples](#templates-and-examples)
@@ -14,18 +15,27 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 ## Articles
 
-- [Building a Second Brain: Overview](https://praxis.fortelabs.co/basboverview/)
+- [Building a Second Brain: The Definitive Introductory Guide](https://fortelabs.com/blog/basboverview/)
 - [How to take smart notes: 10 principles](https://fortelabs.co/blog/how-to-take-smart-notes/)
 - [Progressive Summarization: Part 1](https://fortelabs.co/blog/progressive-summarization-a-practical-technique-for-designing-discoverable-notes)
 - [Progressive Summarization: Part 2](https://fortelabs.co/blog/progressive-summarization-ii-examples-and-metaphors)
 - [Progressive Summarization: Part 3](https://fortelabs.co/blog/progressive-summarization-iii-guidelines-and-principles/)
 - [The PARA Method: A Universal System for Organizing Digital Information](https://fortelabs.co/blog/para/)
 - [One-Touch to Inbox Zero: How I Spend 17 Minutes Per Day on Email](https://fortelabs.co/blog/one-touch-to-inbox-zero)
+- [The 4 Levels of Personal Knowledge Management](https://fortelabs.com/blog/the-4-levels-of-personal-knowledge-management/)
+- [The 9 Biggest Myths and Misconceptions about Building a Second Brain](https://fortelabs.com/blog/9-biggest-myths-and-misconceptions-about-basb/)
+- [Introducing The AI Second Brain](https://fortelabs.com/blog/introducing-the-ai-second-brain/)
+- [Building a Second Brain: The Illustrated Notes](https://maggieappleton.com/basb)
 
 ## Books
 
 - [Building a Second Brain (Book)](https://www.buildingasecondbrain.com/book)
 - [The PARA Method](https://www.buildingasecondbrain.com/para)
+
+## Official Hubs
+
+- [Building a Second Brain Resource Guide](https://www.buildingasecondbrain.com/resources)
+- [Building a Second Brain Podcast](https://www.buildingasecondbrain.com/podcast)
 
 ## Courses
 
@@ -36,8 +46,10 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 ## Videos
 
 ### English
+- [Building a Second Brain: Start Here](https://www.youtube.com/playlist?list=PLVNXAaej57W7xr4274U_DLMzaTAQsHluT)
 - [How to Use and Master Your Second Brain in 2019, by Tiago Forte at ProdCon](https://fortelabs.co/blog/how-to-use-and-master-your-second-brain-in-2019-by-tiago-forte-at-prodcon/)
 - [How to Build a Second Brain, with Tiago Forte](https://fortelabs.co/blog/how-to-build-a-second-brain/)
+- [How to Progressively Summarize a Digital Note](https://www.youtube.com/watch?v=fWFKoVbSwGo)
 
 ### Russian
 - [Building a Second Brain at Knowledge Conf 2019](https://fortelabs.co/blog/building-a-second-brain-at-knowledge-conf-2019/)
@@ -49,6 +61,8 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [The Official Second Brain Notion Template](https://www.buildingasecondbrain.com/notion-template)
 - [PARA Method Template for Notion](https://thomasjfrank.com/templates/para-method-template-for-notion/)
 - [Template for using Obsidian for P.A.R.A.](https://github.com/byarbrough/obsidian-para)
+- [Building a second brain - Workflowy template](https://workflowy.com/template/building-a-second-brain/)
+- [Obsidian AI Second Brain](https://github.com/jamesmcroft/obsidian-ai-second-brain)
 
 ## Tools and Apps
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 ## Articles
 
 - [Building a Second Brain: The Definitive Introductory Guide](https://fortelabs.com/blog/basboverview/)
-- [How to take smart notes: 10 principles](https://fortelabs.co/blog/how-to-take-smart-notes/)
-- [Progressive Summarization: Part 1](https://fortelabs.co/blog/progressive-summarization-a-practical-technique-for-designing-discoverable-notes)
-- [Progressive Summarization: Part 2](https://fortelabs.co/blog/progressive-summarization-ii-examples-and-metaphors)
-- [Progressive Summarization: Part 3](https://fortelabs.co/blog/progressive-summarization-iii-guidelines-and-principles/)
-- [The PARA Method: A Universal System for Organizing Digital Information](https://fortelabs.co/blog/para/)
-- [One-Touch to Inbox Zero: How I Spend 17 Minutes Per Day on Email](https://fortelabs.co/blog/one-touch-to-inbox-zero)
+- [How to take smart notes: 10 principles](https://fortelabs.com/blog/how-to-take-smart-notes/)
+- [Progressive Summarization: Part 1](https://fortelabs.com/blog/progressive-summarization-a-practical-technique-for-designing-discoverable-notes)
+- [Progressive Summarization: Part 2](https://fortelabs.com/blog/progressive-summarization-ii-examples-and-metaphors)
+- [Progressive Summarization: Part 3](https://fortelabs.com/blog/progressive-summarization-iii-guidelines-and-principles/)
+- [The PARA Method: A Universal System for Organizing Digital Information](https://fortelabs.com/blog/para/)
+- [One-Touch to Inbox Zero: How I Spend 17 Minutes Per Day on Email](https://fortelabs.com/blog/one-touch-to-inbox-zero)
 - [The 4 Levels of Personal Knowledge Management](https://fortelabs.com/blog/the-4-levels-of-personal-knowledge-management/)
 - [The 9 Biggest Myths and Misconceptions about Building a Second Brain](https://fortelabs.com/blog/9-biggest-myths-and-misconceptions-about-basb/)
 - [Introducing The AI Second Brain](https://fortelabs.com/blog/introducing-the-ai-second-brain/)
@@ -47,12 +47,12 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 ### English
 - [Building a Second Brain: Start Here](https://www.youtube.com/playlist?list=PLVNXAaej57W7xr4274U_DLMzaTAQsHluT)
-- [How to Use and Master Your Second Brain in 2019, by Tiago Forte at ProdCon](https://fortelabs.co/blog/how-to-use-and-master-your-second-brain-in-2019-by-tiago-forte-at-prodcon/)
-- [How to Build a Second Brain, with Tiago Forte](https://fortelabs.co/blog/how-to-build-a-second-brain/)
+- [How to Use and Master Your Second Brain in 2019, by Tiago Forte at ProdCon](https://fortelabs.com/blog/how-to-use-and-master-your-second-brain-in-2019-by-tiago-forte-at-prodcon/)
+- [How to Build a Second Brain, with Tiago Forte](https://fortelabs.com/blog/how-to-build-a-second-brain/)
 - [How to Progressively Summarize a Digital Note](https://www.youtube.com/watch?v=fWFKoVbSwGo)
 
 ### Russian
-- [Building a Second Brain at Knowledge Conf 2019](https://fortelabs.co/blog/building-a-second-brain-at-knowledge-conf-2019/)
+- [Building a Second Brain at Knowledge Conf 2019](https://fortelabs.com/blog/building-a-second-brain-at-knowledge-conf-2019/)
 
 ## Templates and Examples
 


### PR DESCRIPTION
## Summary
- Add official Building a Second Brain hubs for the resource guide and podcast.
- Add Forte Labs articles on PKM levels, BASB misconceptions, and AI second brain workflows.
- Add practical notes/video/template resources from Maggie Appleton, Tiago Forte's YouTube playlist, Workflowy, and an Obsidian CODE/PARA template.
- Normalize existing Forte Labs links from the older `fortelabs.co` domain to `fortelabs.com` where verified.

## Verification
- Ran `git diff --check`.
- Checked every README external link with `curl -L -A 'Mozilla/5.0'`; all returned HTTP 200.
- Confirmed `jamesmcroft/obsidian-ai-second-brain` is active, public, and explicitly describes CODE/PARA support.
- No formal test suite is present in this minimal awesome-list repo.

## Sources searched
- Web search for Building a Second Brain, PARA, progressive summarization, templates, videos, and official Forte Labs resources.
- GitHub repo/API search for second-brain/PARA/Obsidian/progressive-summarization templates and tools.
- X/Twitter search was attempted through `bird`, but credentials were unavailable in this runtime.
- Reddit/YouTube surfaced via web search results; low-signal reposts and weakly-related productivity posts were not added.
