### PR TITLE
Add diverse BASB implementation resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2026-06-14
 
+- Added diverse independent BASB/PARA implementation resources for Markdown/Git, Obsidian, Notion, public second brains, and AI-assisted Obsidian workflows.
 - Added official Second Brain membership/community, app-selection guidance, Notion implementation, Progressive Summarization, and Talks at Google resources.
 - Added official Forte Labs case studies and app-switching guidance for progressive summarization and Second Brain maintenance.
 - Added Tiago Forte's YouTube channel, PARA video playlist, and Forte Labs video setup roundup.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Building a Second Brain: The Illustrated Notes](https://maggieappleton.com/basb)
 - [My custom second brain setup, part 2: How it works](https://luhr.co/blog/2023/04/21/my-custom-second-brain-setup-part-2-how-it-works/)
 - [How to Build a Second Brain in Obsidian: Complete Setup Guide + Free Templates](https://mattgiaro.com/second-brain-obsidian/)
-- [Public Second Brain with Quartz](https://www.ssp.sh/brain/public-second-brain-with-quartz/)
 - [My workflow for my public second brain](https://www.pelayoarbues.com/notes/My-workflow-for-my-public-second-brain)
 - [Second Brain Case Study: Progressive Summarization in the Intelligence Community](https://fortelabs.com/blog/second-brain-case-study-progressive-summarization-in-the-intelligence-community/)
 - [Second Brain Case Study: Teaching Progressive Summarization in an Undergraduate Classroom](https://fortelabs.com/blog/second-brain-case-study-teaching-progressive-summarization-in-an-undergraduate-classroom-ii/)
@@ -75,6 +74,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [How to Build a Second Brain in Notion](https://fortelabs.com/blog/how-to-build-a-second-brain-in-notion/)
 - [How to Build a Second Brain With Evernote](https://evernote.com/learn/how-to-build-a-second-brain)
 - [Use this Notion second brain template to get organized](https://zapier.com/blog/second-brain-notion-template/)
+- [Public Second Brain with Quartz](https://www.ssp.sh/brain/public-second-brain-with-quartz/)
 
 ## Templates and Examples
 
@@ -87,13 +87,13 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Obsidian AI Second Brain](https://github.com/jamesmcroft/obsidian-ai-second-brain)
 - [PARA Starter Kit](https://forum.obsidian.md/t/para-starter-kit/223)
 - [Second Brain: Crafted, Curated, Connected, Compounded](https://brain.sspaeti.com/)
+- [obsidian-second-brain](https://github.com/eugeniughelbur/obsidian-second-brain)
 
 ## Tools and Apps
 
 ### Free
 - [Obsidian](https://obsidian.md)
 - [Joplin](https://joplinapp.org)
-- [obsidian-second-brain](https://github.com/eugeniughelbur/obsidian-second-brain)
 
 ### Paid
 - [RoamResearch](https://roamresearch.com)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [The 9 Biggest Myths and Misconceptions about Building a Second Brain](https://fortelabs.com/blog/9-biggest-myths-and-misconceptions-about-basb/)
 - [Introducing The AI Second Brain](https://fortelabs.com/blog/introducing-the-ai-second-brain/)
 - [Building a Second Brain: The Illustrated Notes](https://maggieappleton.com/basb)
+- [My custom second brain setup, part 2: How it works](https://luhr.co/blog/2023/04/21/my-custom-second-brain-setup-part-2-how-it-works/)
+- [How to Build a Second Brain in Obsidian: Complete Setup Guide + Free Templates](https://mattgiaro.com/second-brain-obsidian/)
+- [Public Second Brain with Quartz](https://www.ssp.sh/brain/public-second-brain-with-quartz/)
+- [My workflow for my public second brain](https://www.pelayoarbues.com/notes/My-workflow-for-my-public-second-brain)
 - [Second Brain Case Study: Progressive Summarization in the Intelligence Community](https://fortelabs.com/blog/second-brain-case-study-progressive-summarization-in-the-intelligence-community/)
 - [Second Brain Case Study: Teaching Progressive Summarization in an Undergraduate Classroom](https://fortelabs.com/blog/second-brain-case-study-teaching-progressive-summarization-in-an-undergraduate-classroom-ii/)
 - [When You Should Switch Your Second Brain App (And When You Shouldn't)](https://fortelabs.com/blog/when-you-should-switch-your-second-brain-app-and-when-you-shouldnt/)
@@ -70,6 +74,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [PARA Method in Workflowy](https://workflowy.com/help/para-method/)
 - [How to Build a Second Brain in Notion](https://fortelabs.com/blog/how-to-build-a-second-brain-in-notion/)
 - [How to Build a Second Brain With Evernote](https://evernote.com/learn/how-to-build-a-second-brain)
+- [Use this Notion second brain template to get organized](https://zapier.com/blog/second-brain-notion-template/)
 
 ## Templates and Examples
 
@@ -80,12 +85,15 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Template for using Obsidian for P.A.R.A.](https://github.com/byarbrough/obsidian-para)
 - [Building a second brain - Workflowy template](https://workflowy.com/template/building-a-second-brain/)
 - [Obsidian AI Second Brain](https://github.com/jamesmcroft/obsidian-ai-second-brain)
+- [PARA Starter Kit](https://forum.obsidian.md/t/para-starter-kit/223)
+- [Second Brain: Crafted, Curated, Connected, Compounded](https://brain.sspaeti.com/)
 
 ## Tools and Apps
 
 ### Free
 - [Obsidian](https://obsidian.md)
 - [Joplin](https://joplinapp.org)
+- [obsidian-second-brain](https://github.com/eugeniughelbur/obsidian-second-brain)
 
 ### Paid
 - [RoamResearch](https://roamresearch.com)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [The 9 Biggest Myths and Misconceptions about Building a Second Brain](https://fortelabs.com/blog/9-biggest-myths-and-misconceptions-about-basb/)
 - [Introducing The AI Second Brain](https://fortelabs.com/blog/introducing-the-ai-second-brain/)
 - [Building a Second Brain: The Illustrated Notes](https://maggieappleton.com/basb)
+- [My custom second brain setup, part 1: Why go custom?](https://luhr.co/blog/2023/04/19/my-custom-second-brain-setup-part-1-why-go-custom/)
 - [My custom second brain setup, part 2: How it works](https://luhr.co/blog/2023/04/21/my-custom-second-brain-setup-part-2-how-it-works/)
 - [How to Build a Second Brain in Obsidian: Complete Setup Guide + Free Templates](https://mattgiaro.com/second-brain-obsidian/)
 - [My workflow for my public second brain](https://www.pelayoarbues.com/notes/My-workflow-for-my-public-second-brain)


### PR DESCRIPTION
## Summary
- Add independent BASB/PARA implementation resources across Markdown/Git, Obsidian, Notion, and public second-brain publishing workflows.
- Add an Obsidian PARA starter kit, a public second-brain example, and an actively maintained AI-assisted Obsidian second-brain tool.
- Update CHANGELOG.md with the new resource batch.

## Source diversity
- Independent personal sites/blogs: David Luhr, Matt Giaro, Simon Späti, Pelayo Arbués.
- Community/source examples: Obsidian Forum, GitHub.
- Practical app workflow: Zapier Notion guide/template.
- No new Tiago Forte/Forte Labs resources in this run.

## Verification
- `git diff --check`
- Manual HTTP checks for all newly added URLs returned 200.
- Duplicate URL scan found only the pre-existing `sindresorhus/awesome` README badge/reference duplicate.

## Sources searched
- Web search for Obsidian/PARA, Notion second brain templates, Readwise workflows, public second brains, GitHub topics/repos, Obsidian Forum, Reddit/HN result surfaces.
- GitHub repo search for second-brain/Obsidian/PARA resources.
- X/Twitter search attempted via `bird`, but this runtime has no available auth credentials.