### PR TITLE
Add diverse BASB implementation resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-06-15
+
+- Added independent BASB/PARA resources across Zettelkasten comparison, Notion workspace setup, curated public second-brain lists, Obsidian templates, and Logseq/Obsidian PARA helpers.
+
 ## 2026-06-14
 
 - Added practical independent guides and templates for Logseq, Obsidian, Tana, and beginner BASB/PKM setup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2026-06-15
 
-- Added independent BASB/PARA resources across Zettelkasten comparison, Notion workspace setup, curated public second-brain lists, Obsidian templates, and Logseq/Obsidian PARA helpers.
+- Added independent BASB/PARA resources across Zettelkasten comparison, Notion workspace setup, a curated PARA list, Obsidian templates, and Logseq/Obsidian PARA helpers.
 
 ## 2026-06-14
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 - [Second Brain: Crafted, Curated, Connected, Compounded](https://brain.sspaeti.com/)
 - [obsidian-second-brain](https://github.com/eugeniughelbur/obsidian-second-brain)
 - [PARA Template for your Second Brain in Tana](https://www.cortexfutura.com/templates/para/)
-- [second-brain-obsidian-template](https://github.com/geoHeil/second-brain-obsidian-template) - Obsidian starter vault template with note types for projects, meetings, ideas, links, and contacts.
+- [second-brain-obsidian-template](https://github.com/geoHeil/second-brain-obsidian-template)
 
 ## Tools and Apps
 
@@ -116,8 +116,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 
 - [Obsidian](https://obsidian.md)
 - [Joplin](https://joplinapp.org)
-- [Logseq Plugin: Quickly PARA Method](https://github.com/YU000jp/logseq-plugin-quickly-para-method) - Logseq quick menu for tagging and organizing pages by PARA category.
-- [para-shortcuts](https://github.com/gOATiful/para-shortcuts) - Obsidian commands for creating, archiving, restoring, and postponing PARA entries.
+- [Logseq Plugin: Quickly PARA Method](https://github.com/YU000jp/logseq-plugin-quickly-para-method)
+- [para-shortcuts](https://github.com/gOATiful/para-shortcuts)
 
 ### Paid
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 - [Courses](#courses)
 - [Videos](#videos)
 - [Guides](#guides)
+- [Curated Lists](#curated-lists)
 - [Templates and Examples](#templates-and-examples)
 - [Tools and Apps](#tools-and-apps)
 
@@ -41,6 +42,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 - [When You Should Switch Your Second Brain App (And When You Shouldn't)](https://fortelabs.com/blog/when-you-should-switch-your-second-brain-app-and-when-you-shouldnt/)
 - [Peeking Into People's Second Brains: 6 Videos to Inspire Your Second Brain Setup](https://fortelabs.com/blog/peeking-into-peoples-second-brains-6-videos-to-inspire-your-second-brain-setup/)
 - [Test-Driving a New Generation of Second Brain Apps: Obsidian, Tana, and Mem](https://fortelabs.com/blog/test-driving-a-new-generation-of-second-brain-apps-obsidian-tana-and-mem/)
+- [How to Increase Knowledge Productivity: Combine the Zettelkasten Method and Building a Second Brain](https://zettelkasten.de/posts/building-a-second-brain-and-zettelkasten/)
 
 ## Books
 
@@ -86,6 +88,12 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 - [How to build your Second Brain using LogSeq](https://devlizioso.substack.com/p/how-to-build-your-second-brain-using)
 - [LifeOS - Building my second brain with Obsidian](https://forum.obsidian.md/t/lifeos-building-my-second-brain-with-obsidian-para-method-periodic-notes-fullcalendar/62934)
 - [My Complete Obsidian Workflow to Manage My Life](https://mathisgauthey.github.io/my-complete-obsidian-workflow-to-manage-my-life/)
+- [Using PARA to Organize Your Notion Workspace](https://mariepoulin.com/blog/using-para-to-organize-your-notion-workspace/)
+
+## Curated Lists
+
+- [Awesome PARA Method](https://github.com/georgeguimaraes/awesome-PARA-method) - Curated resources and tools for implementing PARA workflows.
+- [Second-Brain](https://github.com/KasperZutterman/Second-Brain) - Public Zettelkasten, second-brain, and digital-garden examples to study.
 
 ## Templates and Examples
 
@@ -100,6 +108,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 - [Second Brain: Crafted, Curated, Connected, Compounded](https://brain.sspaeti.com/)
 - [obsidian-second-brain](https://github.com/eugeniughelbur/obsidian-second-brain)
 - [PARA Template for your Second Brain in Tana](https://www.cortexfutura.com/templates/para/)
+- [second-brain-obsidian-template](https://github.com/geoHeil/second-brain-obsidian-template) - Obsidian starter vault template with note types for projects, meetings, ideas, links, and contacts.
 
 ## Tools and Apps
 
@@ -107,6 +116,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 
 - [Obsidian](https://obsidian.md)
 - [Joplin](https://joplinapp.org)
+- [Logseq Plugin: Quickly PARA Method](https://github.com/YU000jp/logseq-plugin-quickly-para-method) - Logseq quick menu for tagging and organizing pages by PARA category.
+- [para-shortcuts](https://github.com/gOATiful/para-shortcuts) - Obsidian commands for creating, archiving, restoring, and postponing PARA entries.
 
 ### Paid
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 
 ## Curated Lists
 
-- [Awesome PARA Method](https://github.com/georgeguimaraes/awesome-PARA-method) - Curated resources and tools for implementing PARA workflows.
-- [Second-Brain](https://github.com/KasperZutterman/Second-Brain) - Public Zettelkasten, second-brain, and digital-garden examples to study.
+- [Awesome PARA Method](https://github.com/georgeguimaraes/awesome-PARA-method)
 
 ## Templates and Examples
 


### PR DESCRIPTION
## Summary
- Add independent BASB/PARA resources across Zettelkasten comparison, Notion workspace setup, a curated PARA list, Obsidian templates, and Logseq/Obsidian PARA helpers.
- Add a Curated Lists section for meta-resources that help readers find adjacent PARA implementation material.
- Add a 2026-06-15 changelog entry.

## Source diversity
- Zettelkasten.de independent essay for BASB + Zettelkasten comparison.
- Marie Poulin independent Notion/PARA workflow guide.
- GitHub resources from different maintainers: georgeguimaraes, geoHeil, YU000jp, and gOATiful.
- Avoided adding new Forte Labs/Tiago-centered resources this run.

## Sources searched
- Web search for second brain, PARA, Zettelkasten, Readwise, Notion, Obsidian, and Logseq workflows.
- GitHub search for second brain, PARA method, Obsidian PARA, and PKM-related repos.
- Reddit/Hacker News/Obsidian Forum/Logseq community search via web results for practical examples and candidate validation.
- X/Twitter bird CLI was attempted, but auth credentials were unavailable in this cron environment.

## Verification
- npm test
- git diff --check
- Manual duplicate URL scan across README links found no duplicates.
- All 6 final new URLs returned HTTP 200 locally.
