### PR TITLE
Add practical second brain resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2026-06-15
 
+- Added practical non-Forte resources for Notion and Tana workflows, plus open-source Foam and Claude/Obsidian second-brain tooling.
 - Added practical second-brain resources for Obsidian backups, writing workflows, Logseq/Readwise workflows, public digital gardens, and PARA workspace templates.
 - Added practical non-Forte-centered Second Brain resources for Mem, Anytype, Capacities, AI-assisted systems, and broader PKM method comparison.
 - Added independent BASB/PARA resources across Zettelkasten comparison, Notion workspace setup, a curated PARA list, Obsidian templates, and Logseq/Obsidian PARA helpers.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 - [A Guide to Building a Second Brain in Mem](https://newsletter.mem.ai/p/a-guide-to-building-a-second-brain)
 - [PARA Method in Anytype](https://doc.anytype.io/anytype-docs/use-cases/para-method-for-note-taking)
 - [Use this Notion second brain template to get organized](https://zapier.com/blog/second-brain-notion-template/)
-- [How to Build a Second Brain in Notion](https://theeudaimon.com/how-to-build-a-second-brain-in-notion/)
+- [How to Build a Second Brain in Notion - The Eudaimon](https://theeudaimon.com/how-to-build-a-second-brain-in-notion/)
 - [Public Second Brain with Quartz](https://www.ssp.sh/brain/public-second-brain-with-quartz/)
 - [The Beginners Guide to Building a Second Brain](https://www.aidanhelfant.com/the-ultimate-guide-to-starting-your-very-own-second-brain/)
 - [How to build your Second Brain using LogSeq](https://devlizioso.substack.com/p/how-to-build-your-second-brain-using)

--- a/README.md
+++ b/README.md
@@ -88,12 +88,14 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 - [A Guide to Building a Second Brain in Mem](https://newsletter.mem.ai/p/a-guide-to-building-a-second-brain)
 - [PARA Method in Anytype](https://doc.anytype.io/anytype-docs/use-cases/para-method-for-note-taking)
 - [Use this Notion second brain template to get organized](https://zapier.com/blog/second-brain-notion-template/)
+- [How to Build a Second Brain in Notion](https://theeudaimon.com/how-to-build-a-second-brain-in-notion/)
 - [Public Second Brain with Quartz](https://www.ssp.sh/brain/public-second-brain-with-quartz/)
 - [The Beginners Guide to Building a Second Brain](https://www.aidanhelfant.com/the-ultimate-guide-to-starting-your-very-own-second-brain/)
 - [How to build your Second Brain using LogSeq](https://devlizioso.substack.com/p/how-to-build-your-second-brain-using)
 - [LifeOS - Building my second brain with Obsidian](https://forum.obsidian.md/t/lifeos-building-my-second-brain-with-obsidian-para-method-periodic-notes-fullcalendar/62934)
 - [My Complete Obsidian Workflow to Manage My Life](https://mathisgauthey.github.io/my-complete-obsidian-workflow-to-manage-my-life/)
 - [Using PARA to Organize Your Notion Workspace](https://mariepoulin.com/blog/using-para-to-organize-your-notion-workspace/)
+- [Turn Tana Into the Best Bookmark Manager for Your Second Brain](https://www.evchapman.com/blog/turn-tana-into-the-best-bookmark-manager-for-your-second-brain)
 - [Backing up Your Obsidian Vault on Github (for free!)](https://obsidian.rocks/backing-up-your-obsidian-vault-on-github-for-free/)
 - [Building a second brain for writing - with Obsidian](https://thesiswhisperer.com/2023/02/01/building-a-second-brain-for-writing-with-obsidian/)
 - [How I use the Logseq Readwise plugin in my Zettelkasten](https://wilde-at-heart.garden/pages/how-i-use-the-logseq-readwise-plugin-in-my-zettelkasten/)
@@ -127,6 +129,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 
 - [Obsidian](https://obsidian.md)
 - [Joplin](https://joplinapp.org)
+- [Foam](https://github.com/foambubble/foam)
+- [claude-obsidian](https://github.com/AgriciDaniel/claude-obsidian)
 - [Logseq Plugin: Quickly PARA Method](https://github.com/YU000jp/logseq-plugin-quickly-para-method)
 - [para-shortcuts](https://github.com/gOATiful/para-shortcuts)
 


### PR DESCRIPTION
## Summary
- Added two practical workflow guides: a Notion second-brain database setup and a Tana bookmark workflow for second-brain capture/retrieval.
- Added two open-source tools/projects: Foam for VS Code/GitHub-based PKM and claude-obsidian for AI-assisted Obsidian second-brain workflows.
- Updated the 2026-06-15 changelog with a concise entry.

## Source diversity
- Independent blog: The Eudaimon
- Independent Tana workflow creator: Ev Chapman
- Open-source PKM project: foambubble/foam
- Open-source AI + Obsidian project: AgriciDaniel/claude-obsidian

## Research notes
Searched across web results, GitHub repo search, Reddit/Hacker News result surfaces, and tool-specific queries for BASB, PARA, Obsidian, Notion, Tana, Logseq, Readwise, and AI-native second-brain workflows. Rejected several repetitive Obsidian/PARA templates, thin app-comparison pages, low-signal Reddit threads, and duplicate resources already covered in recent PRs.

## Verification
- `npm test`
- `git diff --check`
- README duplicate URL scan returned no duplicates
- New URLs checked manually with `curl -L` and all returned HTTP 200
