### PR TITLE
Add practical second brain workflow resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-06-16
+
+- Added practical Google Keep/Drive/NotebookLM second-brain workflows, Readwise-to-Obsidian capture, and open-source AI-assisted second-brain tools.
+
 ## 2026-06-15
 
 - Added practical non-Forte resources for Notion and Tana workflows, plus open-source Foam and Claude/Obsidian second-brain tooling.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 - [Backing up Your Obsidian Vault on Github (for free!)](https://obsidian.rocks/backing-up-your-obsidian-vault-on-github-for-free/)
 - [Building a second brain for writing - with Obsidian](https://thesiswhisperer.com/2023/02/01/building-a-second-brain-for-writing-with-obsidian/)
 - [How I use the Logseq Readwise plugin in my Zettelkasten](https://wilde-at-heart.garden/pages/how-i-use-the-logseq-readwise-plugin-in-my-zettelkasten/)
+- [Building A Second Brain With Google Keep](https://www.cheerfulegg.com/building-a-second-brain-with-google-keep/)
+- [Building a Second Brain with Google Keep, Drive, and NotebookLM](https://wiobyrne.com/building-a-second-brain-with-google-keep-drive-and-notebooklm/)
 
 ## Curated Lists
 
@@ -133,7 +135,10 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 - [claude-obsidian](https://github.com/AgriciDaniel/claude-obsidian)
 - [Logseq Plugin: Quickly PARA Method](https://github.com/YU000jp/logseq-plugin-quickly-para-method)
 - [para-shortcuts](https://github.com/gOATiful/para-shortcuts)
+- [agent-second-brain](https://github.com/smixs/agent-second-brain)
+- [second-brain-cloudflare](https://github.com/rahilp/second-brain-cloudflare)
 
 ### Paid
 
 - [RoamResearch](https://roamresearch.com)
+- [Readwise Official Obsidian Plugin](https://github.com/readwiseio/obsidian-readwise)

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 - [para-shortcuts](https://github.com/gOATiful/para-shortcuts)
 - [agent-second-brain](https://github.com/smixs/agent-second-brain)
 - [second-brain-cloudflare](https://github.com/rahilp/second-brain-cloudflare)
+- [Readwise Official Obsidian Plugin](https://github.com/readwiseio/obsidian-readwise) (requires a paid Readwise subscription)
 
 ### Paid
 
 - [RoamResearch](https://roamresearch.com)
-- [Readwise Official Obsidian Plugin](https://github.com/readwiseio/obsidian-readwise)


### PR DESCRIPTION
## Summary
- Add two practical Google ecosystem second-brain guides covering Google Keep, Drive, and NotebookLM workflows.
- Add open-source AI-assisted second-brain tools for Obsidian/Telegram capture and Cloudflare-hosted cross-tool memory.
- Add the official Readwise Obsidian plugin as a paid-capture workflow bridge.
- Add a concise 2026-06-16 changelog entry.

## Source diversity notes
- Sources added span independent blogs, GitHub projects, and an official app integration repo.
- Avoided adding more Forte Labs/Tiago-centered links and avoided repeating yesterday's Notion/Tana/Capacities-heavy source pattern.
- Searched web, GitHub repo search, Reddit/forum/web community results, and attempted X/Twitter via bird; bird credentials were unavailable in this runtime.

## Verification
- `npm test`
- `git diff --check`
- README duplicate URL scan
- Manual link checks for all 5 added URLs: 4 returned 200; Ian O'Byrne article returned 403 to curl but rendered via browser/search, and repo CI accepts 403 links via lychee config.

## Sources searched
- Web queries for second-brain Google Keep/NotebookLM, Apple Notes, RemNote, Readwise/Obsidian, PKM workflows, and GitHub templates/tools.
- GitHub searches for second-brain, PARA method, Obsidian second-brain templates, and AI-assisted second-brain tools.
- Reddit/forum-style results for RemNote, Apple Notes, and PKM workflows were reviewed but mostly not added unless source quality was strong.