### PR TITLE
Add practical second brain resource links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2026-06-16
 
+- Added independent PARA, Apple Notes, NotePlan, Johnny.Decimal, SPARTA, and Obsidian progressive-summarization resources.
 - Added practical Google Keep/Drive/NotebookLM second-brain workflows, Readwise-to-Obsidian capture, and open-source AI-assisted second-brain tools.
 
 ## 2026-06-15

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 - [Peeking Into People's Second Brains: 6 Videos to Inspire Your Second Brain Setup](https://fortelabs.com/blog/peeking-into-peoples-second-brains-6-videos-to-inspire-your-second-brain-setup/)
 - [Test-Driving a New Generation of Second Brain Apps: Obsidian, Tana, and Mem](https://fortelabs.com/blog/test-driving-a-new-generation-of-second-brain-apps-obsidian-tana-and-mem/)
 - [How to Increase Knowledge Productivity: Combine the Zettelkasten Method and Building a Second Brain](https://zettelkasten.de/posts/building-a-second-brain-and-zettelkasten/)
+- [The PARA Method: The note-taking and organisation system I've used for years](https://world.hey.com/chrismarr/the-para-method-the-note-taking-and-organisation-system-i-ve-used-for-years-a0b3c512)
+- [How I mixed Johnny Decimal and Second Brain to organize my documents](https://lucaf.eu/2023/02/23/luca-decimal.html)
 
 ## Books
 
@@ -101,6 +103,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 - [How I use the Logseq Readwise plugin in my Zettelkasten](https://wilde-at-heart.garden/pages/how-i-use-the-logseq-readwise-plugin-in-my-zettelkasten/)
 - [Building A Second Brain With Google Keep](https://www.cheerfulegg.com/building-a-second-brain-with-google-keep/)
 - [Building a Second Brain with Google Keep, Drive, and NotebookLM](https://wiobyrne.com/building-a-second-brain-with-google-keep-drive-and-notebooklm/)
+- [Second Brain-ing My Apple Notes](https://theshubox.com/2024/01/second-brain-ing-my-apple-notes.html)
+- [How to organize your notes and folders using Johnny.Decimal and PARA](https://help.noteplan.co/article/155-how-to-organize-your-notes-and-folders-using-johnny-decimal-and-para)
+- [S.P.A.R.T.A. system for organizing my life and work](https://talk.macpowerusers.com/t/s-p-a-r-t-a-system-for-organizing-my-life-and-work/32092)
 
 ## Curated Lists
 
@@ -138,6 +143,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 - [agent-second-brain](https://github.com/smixs/agent-second-brain)
 - [second-brain-cloudflare](https://github.com/rahilp/second-brain-cloudflare)
 - [Readwise Official Obsidian Plugin](https://github.com/readwiseio/obsidian-readwise) (requires a paid Readwise subscription)
+- [Obsidian Progressive Summarization](https://github.com/zhixindev/obsidian-progressive-summarization)
 
 ### Paid
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 - [Peeking Into People's Second Brains: 6 Videos to Inspire Your Second Brain Setup](https://fortelabs.com/blog/peeking-into-peoples-second-brains-6-videos-to-inspire-your-second-brain-setup/)
 - [Test-Driving a New Generation of Second Brain Apps: Obsidian, Tana, and Mem](https://fortelabs.com/blog/test-driving-a-new-generation-of-second-brain-apps-obsidian-tana-and-mem/)
 - [How to Increase Knowledge Productivity: Combine the Zettelkasten Method and Building a Second Brain](https://zettelkasten.de/posts/building-a-second-brain-and-zettelkasten/)
-- [The PARA Method: The note-taking and organisation system I've used for years](https://world.hey.com/chrismarr/the-para-method-the-note-taking-and-organisation-system-i-ve-used-for-years-a0b3c512)
-- [How I mixed Johnny Decimal and Second Brain to organize my documents](https://lucaf.eu/2023/02/23/luca-decimal.html)
 
 ## Books
 
@@ -103,6 +101,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 - [How I use the Logseq Readwise plugin in my Zettelkasten](https://wilde-at-heart.garden/pages/how-i-use-the-logseq-readwise-plugin-in-my-zettelkasten/)
 - [Building A Second Brain With Google Keep](https://www.cheerfulegg.com/building-a-second-brain-with-google-keep/)
 - [Building a Second Brain with Google Keep, Drive, and NotebookLM](https://wiobyrne.com/building-a-second-brain-with-google-keep-drive-and-notebooklm/)
+- [The PARA Method: The note-taking and organisation system I've used for years](https://world.hey.com/chrismarr/the-para-method-the-note-taking-and-organisation-system-i-ve-used-for-years-a0b3c512)
+- [How I mixed Johnny Decimal and Second Brain to organize my documents](https://lucaf.eu/2023/02/23/luca-decimal.html)
 - [Second Brain-ing My Apple Notes](https://theshubox.com/2024/01/second-brain-ing-my-apple-notes.html)
 - [How to organize your notes and folders using Johnny.Decimal and PARA](https://help.noteplan.co/article/155-how-to-organize-your-notes-and-folders-using-johnny-decimal-and-para)
 - [S.P.A.R.T.A. system for organizing my life and work](https://talk.macpowerusers.com/t/s-p-a-r-t-a-system-for-organizing-my-life-and-work/32092)


### PR DESCRIPTION
## Summary
- Add six practical BASB/PARA resources across Apple Notes, NotePlan, Johnny.Decimal, SPARTA, and Obsidian progressive summarization
- Add a concise changelog entry for the new resources

## Source diversity
- Personal/practitioner essays: Chris Marr, Luca Franceschini, The Shu Box
- App/community docs and workflows: NotePlan Knowledge Base, MPU Talk
- Open-source tooling: Obsidian Progressive Summarization plugin
- Avoided centering this run on Tiago/Forte Labs or repeating the recent Google/Readwise/AI-tool-heavy source pattern

## Sources searched
- Web search for PARA, second brain, Apple Notes, NotePlan, Johnny.Decimal, progressive summarization, Obsidian, Dendron, RemNote, OneNote, Bear, Google Drive, and community workflows
- GitHub repository search for second-brain/PARA/progressive-summarization tools and templates
- HN, Reddit, Obsidian Forum, and MPU Talk community searches
- X/Twitter bird check attempted, but local credentials were unavailable

## Verification
- npm test
- git diff --check
- Duplicate README URL scan returned no duplicates
- Manual curl check: all six new URLs returned HTTP 200

## Notes
- Skipped thinner/generic app comparison posts and recently repeated AI/Readwise/Google-style resources in favor of durable implementation examples.